### PR TITLE
fix: reset wsClient when closing connection

### DIFF
--- a/src/midjourney.ts
+++ b/src/midjourney.ts
@@ -161,6 +161,7 @@ export class Midjourney extends MidjourneyMessage {
   Close() {
     if (this.wsClient) {
       this.wsClient.close();
+      this.wsClient = null;
     }
   }
 }


### PR DESCRIPTION
Thank you for a great project. I noticed a little bug when closing the connection.

Calling `client.init()` after `client.Close()` doesn't open up a new WebSocket connection. This single line should fix it.

#115 