### PR TITLE
Allow progress updates without images, for 2x and 4x upscales for exa…

### DIFF
--- a/src/discord.ws.ts
+++ b/src/discord.ws.ts
@@ -433,6 +433,21 @@ export class WsMessage {
     event.prompt = content;
     //not image
     if (!attachments || attachments.length === 0) {
+
+      const progress =  content2progress(content);
+
+      if (( this.config.UpdateProgressWithoutImage ) && ( progress !== "" )) {
+        const MJmsg: MJMessage = {
+          uri: this.config.EmptyImageUri ? this.config.EmptyImageUri : "",
+          content: content,
+          flags: flags,
+          progress: progress,
+        };
+        const eventMsg: MJEmit = {
+          message: MJmsg,
+        };
+        this.emitImage(event.nonce, eventMsg);  
+      }
       return;
     }
 

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -22,6 +22,8 @@ export interface MJConfig {
   ApiInterval: number;
   WebSocket: WebSocketCl;
   ImageProxy: string;
+  UpdateProgressWithoutImage?: boolean;
+  EmptyImageUri?: string;
 }
 export interface MJConfigParam {
   SalaiToken: string; //DISCORD_TOKEN
@@ -41,6 +43,8 @@ export interface MJConfigParam {
   WsBaseUrl?: string;
   fetch?: FetchFn; //Node.js<18 need node.fetch Or proxy
   WebSocket?: WebSocketCl; //isomorphic-ws Or proxy
+  UpdateProgressWithoutImage?: boolean; // Send progress even if no image ( upscale 2x, 4x )
+  EmptyImageUri?: string;   // Uri for image progress when no image is available
 }
 
 export const DefaultMJConfig: MJConfig = {
@@ -58,4 +62,6 @@ export const DefaultMJConfig: MJConfig = {
   WsBaseUrl: "wss://gateway.discord.gg/?encoding=json&v=9",
   fetch: fetch,
   WebSocket: WebSocket,
+  UpdateProgressWithoutImage: false,
+  EmptyImageUri: "about:blank",
 };


### PR DESCRIPTION
With the new upscale x2 and x4, we receive progress updates but the attachments list is empty, so there is no image progress sent to the client. These upscales are very slow so it creates a long delay without any progress and can cause problems to client applications.
With this small patch, if the user configures UpdateProgressWithoutImage to "true", these updates will be sent with the "EmptyImageUri" from the config ( defaults to "about:blank" ).
By default behavior is the same as before.