### PR TITLE
Fix Discord sending nonce when creating new message

### DIFF
--- a/src/discord.ws.ts
+++ b/src/discord.ws.ts
@@ -176,7 +176,7 @@ export class WsMessage {
       }
     }
 
-    if (!nonce && attachments?.length > 0 && components?.length > 0) {
+    if (attachments?.length > 0 && components?.length > 0) {
       this.done(message);
       return;
     }


### PR DESCRIPTION
The api stopped returning a result because it was checking for `!nonce` in the `createMessage` handler. This PR fixes that by removing that check. 